### PR TITLE
Use builtin zlib instead of C interop

### DIFF
--- a/types.v
+++ b/types.v
@@ -1,33 +1,5 @@
 module vpng
 
-// * zlib bindings *
-#flag -lz
-#include <zlib.h>
-
-struct C.z_stream_s {
-	next_in   voidptr
-	avail_in  u32
-	next_out  voidptr
-	avail_out u32
-	total_out u64
-	zalloc    voidptr
-	zfree     voidptr
-	opaque    voidptr
-}
-
-fn C.inflateInit(&C.z_stream_s)
-
-fn C.inflate(&C.z_stream_s, int)
-
-fn C.inflateEnd(&C.z_stream_s)
-
-fn C.deflateInit(&C.z_stream_s, int)
-
-fn C.deflate(&C.z_stream_s, int)
-
-fn C.deflateEnd(&C.z_stream_s)
-
-// ****
 pub enum PixelType {
 	indexed
 	grayscale

--- a/write.v
+++ b/write.v
@@ -1,6 +1,7 @@
 module vpng
 
 import os
+import compress.zlib
 
 fn write_(png PngFile, filename string) {
 	mut file_bytes := []u8{}
@@ -62,36 +63,11 @@ fn idat_chunk(mut file_bytes []u8, mut cs CRC, png PngFile) {
 		}
 	}
 
-	out_len := idat_bytes.len + idat_bytes.len * 2
-	out := unsafe { malloc(out_len) }
-	defstream := C.z_stream_s{
-		zalloc: 0
-		zfree: 0
-		opaque: 0
-		avail_in: u32(idat_bytes.len)
-		next_in: idat_bytes.bytestr().str
-		avail_out: u32(out_len)
-		next_out: out
+	out := zlib.compress(idat_bytes) or {
+		panic('failed to compress IDAT chunks')
 	}
-	C.deflateInit(&defstream, 9)
-	C.deflate(&defstream, 4)
-	C.deflateEnd(&defstream)
 	mut out_bytes := [u8(`I`), `D`, `A`, `T`]
-	mut max := 0
-	for i := out_len; i > 0; i-- {
-		unsafe {
-			if int(out[i]) != 0 {
-				max = i + 1
-				max += 4 - (max % 3)
-				break
-			}
-		}
-	}
-	for i in 0 .. max {
-		unsafe {
-			out_bytes << u8(out[i])
-		}
-	}
+	out_bytes << out
 	file_bytes << int_to_bytes(out_bytes.len - 4)
 	file_bytes << out_bytes
 	file_bytes << int_to_bytes(int(cs.crc(out_bytes, out_bytes.len)))


### PR DESCRIPTION
Remaster of PR #9:

There are two reasons:
1. V already has builtin [`compress.zlib`](https://modules.vlang.io/compress.zlib.html) module
2. I caught some C interop errors

P.S. This is quickfix so code is kinda wacky